### PR TITLE
SI-2567 Limit query request time

### DIFF
--- a/charts/telemetry-api/values.yaml
+++ b/charts/telemetry-api/values.yaml
@@ -31,6 +31,7 @@ env:
   TOKEN_EXCHANGE_JWK_KEY_SET_URL: http://dex-roles-rights.dev.svc.cluster.local:5556/keys
   TOKEN_EXCHANGE_ISSUER_URL: https://auth-roles-rights.dev.dimo.zone
   VEHICLE_NFT_ADDRESS: '0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8'
+  MAX_REQUEST_DURATION: 5s
 service:
   type: ClusterIP
   ports:

--- a/charts/telemetry-api/values.yaml
+++ b/charts/telemetry-api/values.yaml
@@ -31,7 +31,7 @@ env:
   TOKEN_EXCHANGE_JWK_KEY_SET_URL: http://dex-roles-rights.dev.svc.cluster.local:5556/keys
   TOKEN_EXCHANGE_ISSUER_URL: https://auth-roles-rights.dev.dimo.zone
   VEHICLE_NFT_ADDRESS: '0x45fbCD3ef7361d156e8b16F5538AE36DEdf61Da8'
-  MAX_REQUEST_DURATION: 5s
+  MAX_REQUEST_DURATION: "5s"
 service:
   type: ClusterIP
   ports:

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -12,4 +12,5 @@ type Settings struct {
 	TokenExchangeJWTKeySetURL string `yaml:"TOKEN_EXCHANGE_JWK_KEY_SET_URL"`
 	TokenExchangeIssuer       string `yaml:"TOKEN_EXCHANGE_ISSUER_URL"`
 	VehicleNFTAddress         string `yaml:"VEHICLE_NFT_ADDRESS"`
+	MaxRequestDuration        string `yaml:"MAX_REQUEST_DURATION"`
 }

--- a/internal/limits/middleware.go
+++ b/internal/limits/middleware.go
@@ -1,0 +1,39 @@
+package limits
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Limiter adds request timeouts to HTTP handlers.
+type Limiter struct {
+	maxRequestDuration time.Duration
+}
+
+// New creates a new Limiter, which adds the given request timeout to HTTP handlers.
+// The string maxRequestDuration must be parseable as a positive time.Duration; e.g.,
+// "5m", "30s".
+func New(maxRequestDuration string) (*Limiter, error) {
+	mrd, err := time.ParseDuration(maxRequestDuration)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse duration %q: %w", maxRequestDuration, err)
+	}
+
+	if mrd <= 0 {
+		return nil, fmt.Errorf("duration %s was not positive", maxRequestDuration)
+	}
+
+	return &Limiter{maxRequestDuration: mrd}, nil
+}
+
+// AddRequestTimeout wraps the given handler in a new one that cancels the
+// request context after the duration specified in the limiter.
+func (l *Limiter) AddRequestTimeout(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), l.maxRequestDuration)
+		defer cancel()
+		next.ServeHTTP(w, r.Clone(ctx))
+	})
+}

--- a/internal/repositories/validate.go
+++ b/internal/repositories/validate.go
@@ -2,13 +2,10 @@ package repositories
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DIMO-Network/telemetry-api/internal/graph/model"
 	"github.com/DIMO-Network/telemetry-api/internal/service/ch"
 )
-
-var twoWeeks = 14 * 24 * time.Hour
 
 // ValidationError is an error type for validation errors.
 type ValidationError string
@@ -24,11 +21,6 @@ func validateAggSigArgs(args *model.AggregatedSignalArgs) error {
 	}
 	if args.FromTS.After(args.ToTS) {
 		return ValidationError("from timestamp is after to timestamp")
-	}
-
-	// check if time range is greater than 2 weeks
-	if args.ToTS.Sub(args.FromTS) > twoWeeks {
-		return ValidationError("time range is greater than two weeks")
 	}
 
 	if args.Interval < 1 {


### PR DESCRIPTION
* Add a new setting `MAX_REQUEST_DURATION`. Must be parseable as a `time.Duration` and positive. I put `5s` in there to start.
* New dumb middleware
  ```go
  limiter, _ := limits.New("5s")
  handler = limiter.AddRequestTimeout(handler)
  ```
* Remove the two week span limit on aggregation queries.