### PR TITLE
Ex 3247 improve aggregation timestamps for telemetry api

### DIFF
--- a/e2e/aproximate_location_test.go
+++ b/e2e/aproximate_location_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -127,14 +128,15 @@ func TestApproximateLocation(t *testing.T) {
 	assert.Equal(t, expectedEndLatLong.Lng, result.SignalLatest.ApproxLong.Value)
 	assert.Nil(t, result.SignalLatest.Lat)
 	assert.Nil(t, result.SignalLatest.Long)
-
-	query = `query {
-		signals(tokenId:39718, from: "2020-04-15T09:21:19Z", to: "2025-04-27T09:21:19Z", interval:"24h"){
+	fromTime := "2024-11-19T09:21:19Z"
+	fromtTimePlus24 := "2024-11-20T09:21:19Z"
+	query = fmt.Sprintf(`query {
+		signals(tokenId:39718, from: "%s", to: "2025-04-27T09:21:19Z", interval:"24h"){
 			timestamp
 			currentLocationApproximateLatitude(agg: FIRST)
 			currentLocationApproximateLongitude(agg: FIRST)
 		}
-	}`
+	}`, fromTime)
 	// Execute request
 	aggResult := ApproxAgg{}
 	err = telemetryClient.Post(query, &aggResult, WithToken(token))
@@ -142,23 +144,23 @@ func TestApproximateLocation(t *testing.T) {
 
 	require.Len(t, aggResult.Signals, 2)
 	// Assert the results
-	assert.Equal(t, locationTime.Add(-time.Hour*24).Truncate(time.Hour*24).Format(time.RFC3339), aggResult.Signals[0].Timestamp)
+	assert.Equal(t, fromTime, aggResult.Signals[0].Timestamp)
 	assert.Equal(t, expectedStartLatLong.Lat, *aggResult.Signals[0].ApproxLat)
 	assert.Equal(t, expectedStartLatLong.Lng, *aggResult.Signals[0].ApproxLong)
 
-	assert.Equal(t, locationTime.Truncate(time.Hour*24).Format(time.RFC3339), aggResult.Signals[1].Timestamp)
+	assert.Equal(t, fromtTimePlus24, aggResult.Signals[1].Timestamp)
 	assert.Equal(t, expectedEndLatLong.Lat, *aggResult.Signals[1].ApproxLat)
 	assert.Equal(t, expectedEndLatLong.Lng, *aggResult.Signals[1].ApproxLong)
 
-	query = `query {
-		signals(tokenId:39718, from: "2020-04-15T09:21:19Z", to: "2025-04-27T09:21:19Z", interval:"24h"){
+	query = fmt.Sprintf(`query {
+		signals(tokenId:39718, from: "%s", to: "2025-04-27T09:21:19Z", interval:"24h"){
 			timestamp
 			currentLocationApproximateLatitude(agg: FIRST)
 			currentLocationApproximateLongitude(agg: FIRST)
 			currentLocationLatitude(agg: FIRST)
 			currentLocationLongitude(agg: FIRST)
 		}
-	}`
+	}`, fromTime)
 	// Execute request
 	aggResult = ApproxAgg{}
 	err = telemetryClient.Post(query, &aggResult, WithToken(token))
@@ -166,13 +168,13 @@ func TestApproximateLocation(t *testing.T) {
 
 	// Assert the results
 	require.Len(t, aggResult.Signals, 2)
-	assert.Equal(t, locationTime.Add(-time.Hour*24).Truncate(time.Hour*24).Format(time.RFC3339), aggResult.Signals[0].Timestamp)
+	assert.Equal(t, fromTime, aggResult.Signals[0].Timestamp)
 	assert.Equal(t, expectedStartLatLong.Lat, *aggResult.Signals[0].ApproxLat)
 	assert.Equal(t, expectedStartLatLong.Lng, *aggResult.Signals[0].ApproxLong)
 	assert.Nil(t, aggResult.Signals[0].Lat)
 	assert.Nil(t, aggResult.Signals[0].Long)
 
-	assert.Equal(t, locationTime.Truncate(time.Hour*24).Format(time.RFC3339), aggResult.Signals[1].Timestamp)
+	assert.Equal(t, fromtTimePlus24, aggResult.Signals[1].Timestamp)
 	assert.Equal(t, expectedEndLatLong.Lat, *aggResult.Signals[1].ApproxLat)
 	assert.Equal(t, expectedEndLatLong.Lng, *aggResult.Signals[1].ApproxLong)
 	assert.Nil(t, aggResult.Signals[1].Lat)

--- a/e2e/setup_test.go
+++ b/e2e/setup_test.go
@@ -30,6 +30,7 @@ var (
 	testServices *TestServices
 	once         sync.Once
 	cleanupOnce  sync.Once
+	srvcLock     sync.Mutex
 	cleanup      func()
 )
 
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 // GetTestServices returns singleton instances of all test services
 func GetTestServices(t *testing.T) *TestServices {
 	t.Helper()
-
+	srvcLock.Lock()
 	once.Do(func() {
 		settings := config.Settings{
 			Port:                         8080,
@@ -92,6 +93,7 @@ func GetTestServices(t *testing.T) *TestServices {
 			})
 		}
 	})
+	srvcLock.Unlock()
 	return testServices
 }
 

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -107,9 +107,23 @@ func withSource(source string) qm.QueryMod {
 }
 
 // selectInterval adds a SELECT clause to the query to select the interval group based on the given milliSeconds.
-// Example: 'SELECT toStartOfInterval(Timestamp, toIntervalMillisecond(?)) as group_timestamp'.
-func selectInterval(milliSeconds int64) qm.QueryMod {
-	return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMillisecond(%d)) as %s", vss.TimestampCol, milliSeconds, IntervalGroup))
+// Normalize timestamps relative to a specific origin point (by subtracting it)
+// Round to interval boundaries using toStartOfInterval
+// Restore the original time reference (by adding the origin back).
+func selectInterval(milliSeconds int64, origin time.Time) qm.QueryMod {
+	// TODO (Kevin): Replace this function with simpler toStartOfInterval once ClickHouse prod server is >= v24.9
+	// return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMillisecond(%d), fromUnixTimestamp64Micro(%d)) as %s", vss.TimestampCol, milliSeconds, origin.UnixMicro(), intervalGroup))
+	// https://github.com/ClickHouse/ClickHouse/commit/2c35d53bf67cd80edb4389feac11bcff67233eeb
+	return qm.Select(fmt.Sprintf(`
+	fromUnixTimestamp64Micro(
+		toUnixTimestamp64Micro(
+			toStartOfInterval(
+				fromUnixTimestamp64Micro(toUnixTimestamp64Micro(%s) - %d),
+				toIntervalMillisecond(%d)
+			)
+		) + %d
+	) as %s`,
+		vss.TimestampCol, origin.UnixMicro(), milliSeconds, origin.UnixMicro(), IntervalGroup))
 }
 
 func selectNumberAggs(numberAggs []model.FloatSignalArgs) qm.QueryMod {
@@ -330,7 +344,7 @@ func getAggQuery(aggArgs *model.AggregatedSignalArgs) (string, []any, error) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.NameCol),
 		qm.Select(AggCol),
-		selectInterval(aggArgs.Interval),
+		selectInterval(aggArgs.Interval, aggArgs.FromTS),
 		selectNumberAggs(floatArgs),
 		selectStringAggs(stringArgs),
 		qm.Where(tokenIDWhere, aggArgs.TokenID),


### PR DESCRIPTION
Update Agg queries to always return intervals starting at the from timestamp.

This means that the returned timestamps will no longer be cleanly rounded 
For example previously this query would return the timestamps like this
`2024-11-19T00:00:00Z, 2024-11-20T00:00:00Z, 2024-11-21T00:00:00Z, 2024-11-22T00:00:00Z...`and instead will be 
`2024-11-19T09:21:19Z, 2024-11-20T09:21:19Z, 2024-11-21T09:21:19Z, 2024-11-22T09:21:19Z...`
```gql
signals(tokenId:39718, from: "2024-11-19T09:21:19Z", to: "2025-04-27T09:21:19Z", interval:"24h"){
	timestamp
	currentLocationApproximateLatitude(agg: FIRST)
	currentLocationApproximateLongitude(agg: FIRST)
}
```