### PR TITLE
refactor: centralize middleware and auth logging

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -22,6 +24,7 @@ import (
 	"github.com/DIMO-Network/telemetry-api/internal/service/fetchapi"
 	"github.com/DIMO-Network/telemetry-api/internal/service/identity"
 	"github.com/DIMO-Network/telemetry-api/pkg/errorhandler"
+	"github.com/rs/zerolog"
 )
 
 func init() {
@@ -81,14 +84,20 @@ func New(settings config.Settings) (*App, error) {
 		return nil, fmt.Errorf("couldn't create request time limit middleware: %w", err)
 	}
 
-	authedHandler := limiter.AddRequestTimeout(
-		authMiddleware.CheckJWT(
-			auth.AddClaimHandler(server, settings.VehicleNFTAddress, settings.ManufacturerNFTAddress),
+	serverHandler := panicRecoveryMiddleware(
+		loggerMiddleware(
+			limiter.AddRequestTimeout(
+				authMiddleware.CheckJWT(
+					authLoggerMiddleware(
+						auth.AddClaimHandler(server, settings.VehicleNFTAddress, settings.ManufacturerNFTAddress),
+					),
+				),
+			),
 		),
 	)
 
 	return &App{
-		Handler: authedHandler,
+		Handler: serverHandler,
 		cleanup: func() {
 			// TODO add cleanup logic for closing connections
 		},
@@ -131,4 +140,48 @@ func newDefaultServer(es graphql.ExecutableSchema) *handler.Server {
 	srv.SetErrorPresenter(errorhandler.ErrorPresenter)
 
 	return srv
+}
+
+// LoggerMiddleware adds the source IP to the logger.
+func LoggerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// get source ip from request could be cloudflare proxy
+		sourceIP := r.Header.Get("X-Forwarded-For")
+		if sourceIP == "" {
+			sourceIP = r.Header.Get("X-Real-IP")
+		}
+		if sourceIP == "" {
+			sourceIP = r.RemoteAddr
+		}
+		loggerCtx := zerolog.Ctx(r.Context()).With().Str("method", r.Method).Str("path", r.URL.Path).Str("sourceIp", sourceIP).Logger().WithContext(r.Context())
+		r = r.WithContext(loggerCtx)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// authLoggerMiddleware adds the authenticated user to the logger
+func authLoggerMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		validateClaims, ok := auth.GetValidatedClaims(r)
+		if !ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+		loggerCtx := zerolog.Ctx(r.Context()).With().Str("jwtSubject", validateClaims.RegisteredClaims.Subject).Logger()
+		r = r.WithContext(loggerCtx.WithContext(r.Context()))
+		next.ServeHTTP(w, r)
+	})
+}
+
+// PanicRecoveryMiddleware recovers from panics and logs them.
+func PanicRecoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", err, debug.Stack())
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -64,8 +64,8 @@ func AddClaimHandler(next http.Handler, vehicleAddr, mfrAddr common.Address) htt
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims, ok := r.Context().Value(jwtmiddleware.ContextKey{}).(*validator.ValidatedClaims)
-		if !ok || claims == nil || claims.CustomClaims == nil {
+		claims, ok := GetValidatedClaims(r)
+		if !ok || claims.CustomClaims == nil {
 			// unathorized calls will not have a claims.
 			next.ServeHTTP(w, r)
 			return
@@ -84,6 +84,19 @@ func AddClaimHandler(next http.Handler, vehicleAddr, mfrAddr common.Address) htt
 		r = r.Clone(context.WithValue(r.Context(), TelemetryClaimContextKey{}, telClaim))
 		next.ServeHTTP(w, r)
 	})
+}
+
+// GetValidatedClaims returns the validated claims from the request context.
+func GetValidatedClaims(r *http.Request) (*validator.ValidatedClaims, bool) {
+	claim := r.Context().Value(jwtmiddleware.ContextKey{})
+	if claim == nil {
+		return nil, false
+	}
+	validateClaim, ok := claim.(*validator.ValidatedClaims)
+	if !ok {
+		return nil, false
+	}
+	return validateClaim, true
 }
 
 // ErrorHandler is a custom error handler for the jwt middleware. It logs the error and then calls the default error handler.


### PR DESCRIPTION
- Move middleware functions from main.go to internal/app/app.go
   - Nice to have it all in one spot. It was only in main because when we were dealing with the previous downtime.
- Add authLoggerMiddleware to log authenticated JWT subject
- Restructure server handler chain for better organization