### PR TITLE
Use toStartOfInterval with origin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.73
 	github.com/ClickHouse/clickhouse-go/v2 v2.35.0
 	github.com/DIMO-Network/attestation-api v0.0.22
-	github.com/DIMO-Network/clickhouse-infra v0.0.3
+	github.com/DIMO-Network/clickhouse-infra v0.0.4-0.20250622180951-cbd98210a1fa
 	github.com/DIMO-Network/cloudevent v0.1.0
 	github.com/DIMO-Network/credit-tracker v0.0.0-20250603213155-96e2e9965b01
 	github.com/DIMO-Network/fetch-api v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/DIMO-Network/attestation-api v0.0.22 h1:iQwiPCV1P/4rD1HkbGJPs8BfjzO9T
 github.com/DIMO-Network/attestation-api v0.0.22/go.mod h1:U6vAf/84o9jd6W+rZzLs+YjumSuzSskFLDp4SC1zJP4=
 github.com/DIMO-Network/clickhouse-infra v0.0.3 h1:B6/4IY9IxLcyydET14IjHUT+A5SDEis7p//DoFzrMk4=
 github.com/DIMO-Network/clickhouse-infra v0.0.3/go.mod h1:NtpQ1btkPzebDvpYYygeqiiBmJ/q5oJb/T/JWzUVRlk=
+github.com/DIMO-Network/clickhouse-infra v0.0.4-0.20250622180951-cbd98210a1fa h1:OrNYrvgrYHvl2zyAz3K6z8llWQFwlQt8w2LMtwfNGR4=
+github.com/DIMO-Network/clickhouse-infra v0.0.4-0.20250622180951-cbd98210a1fa/go.mod h1:NtpQ1btkPzebDvpYYygeqiiBmJ/q5oJb/T/JWzUVRlk=
 github.com/DIMO-Network/cloudevent v0.1.0 h1:ze0ngJQBXjSSyBnEAUO+YvClvkqM68kNko/czY3GfLo=
 github.com/DIMO-Network/cloudevent v0.1.0/go.mod h1:RS9Byb0ycb5b7OFe9y+xpF0nkR4pYYS6Om/ccs3N5Z4=
 github.com/DIMO-Network/credit-tracker v0.0.0-20250603213155-96e2e9965b01 h1:KW+yKmX+LreOfSKt0lqEitKN20PaUcMkThIxYLSJOsM=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1M
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DIMO-Network/attestation-api v0.0.22 h1:iQwiPCV1P/4rD1HkbGJPs8BfjzO9TIOAA7mgbBvQOeU=
 github.com/DIMO-Network/attestation-api v0.0.22/go.mod h1:U6vAf/84o9jd6W+rZzLs+YjumSuzSskFLDp4SC1zJP4=
-github.com/DIMO-Network/clickhouse-infra v0.0.3 h1:B6/4IY9IxLcyydET14IjHUT+A5SDEis7p//DoFzrMk4=
-github.com/DIMO-Network/clickhouse-infra v0.0.3/go.mod h1:NtpQ1btkPzebDvpYYygeqiiBmJ/q5oJb/T/JWzUVRlk=
 github.com/DIMO-Network/clickhouse-infra v0.0.4-0.20250622180951-cbd98210a1fa h1:OrNYrvgrYHvl2zyAz3K6z8llWQFwlQt8w2LMtwfNGR4=
 github.com/DIMO-Network/clickhouse-infra v0.0.4-0.20250622180951-cbd98210a1fa/go.mod h1:NtpQ1btkPzebDvpYYygeqiiBmJ/q5oJb/T/JWzUVRlk=
 github.com/DIMO-Network/cloudevent v0.1.0 h1:ze0ngJQBXjSSyBnEAUO+YvClvkqM68kNko/czY3GfLo=

--- a/internal/graph/arguments.go
+++ b/internal/graph/arguments.go
@@ -13,7 +13,7 @@ import (
 // aggregationArgsFromContext creates an aggregated signals arguments from the context and the provided arguments.
 func aggregationArgsFromContext(ctx context.Context, tokenID int, interval string, from time.Time, to time.Time, filter *model.SignalFilter) (*model.AggregatedSignalArgs, error) {
 	// 1h 1s
-	intervalInt, err := getIntervalMS(interval)
+	intervalInt, err := getIntervalMicroseconds(interval)
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +105,17 @@ func latestArgsFromContext(ctx context.Context, tokenID int, filter *model.Signa
 	return &latestArgs, nil
 }
 
-// getIntervalMS parses the interval string and returns the milliseconds.
-func getIntervalMS(interval string) (int64, error) {
+// getIntervalMicroseconds parses the interval string and returns the number
+// of microseconds the interval contains.
+//
+// We use microseconds because the ClickHouse column is DateTime64(6, 'UTC').
+// Go stores durations in nanoseconds, so we do lose some precision.
+func getIntervalMicroseconds(interval string) (int64, error) {
 	dur, err := time.ParseDuration(interval)
 	if err != nil {
 		return 0, fmt.Errorf("failed parsing interval: %w", err)
 	}
-	return dur.Milliseconds(), nil
+	return dur.Microseconds(), nil
 }
 
 // isSignal checks if the field has the isSignal directive.

--- a/internal/graph/model/signalArgs.go
+++ b/internal/graph/model/signalArgs.go
@@ -37,7 +37,7 @@ type AggregatedSignalArgs struct {
 	FromTS time.Time
 	// ToTS is the end timestamp for the data range.
 	ToTS time.Time
-	// Interval in which the data is aggregated in milliseconds.
+	// Interval in which the data is aggregated in microseconds.
 	Interval int64
 	// FloatArgs represents arguments for each float signal.
 	FloatArgs map[FloatSignalArgs]struct{}

--- a/internal/service/ch/ch_test.go
+++ b/internal/service/ch/ch_test.go
@@ -80,7 +80,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 			},
 			expected: []model.AggSignal{},
 		},
@@ -92,7 +92,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				FloatArgs: map[model.FloatSignalArgs]struct{}{
 					{
 						Name: vss.FieldSpeed,
@@ -117,7 +117,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				FloatArgs: map[model.FloatSignalArgs]struct{}{
 					{
 						Name: vss.FieldSpeed,
@@ -155,7 +155,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				FloatArgs: map[model.FloatSignalArgs]struct{}{
 					{
 						Name: vss.FieldSpeed,
@@ -180,7 +180,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				StringArgs: map[model.StringSignalArgs]struct{}{
 					{
 						Name: vss.FieldPowertrainType,
@@ -208,7 +208,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     c.dataStartTime.Add(time.Hour),
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				StringArgs: map[model.StringSignalArgs]struct{}{
 					{
 						Name: vss.FieldPowertrainType,
@@ -233,7 +233,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				FloatArgs: map[model.FloatSignalArgs]struct{}{
 					{
 						Name: vss.FieldSpeed,
@@ -258,7 +258,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				FloatArgs: map[model.FloatSignalArgs]struct{}{
 					{
 						Name: vss.FieldSpeed,
@@ -283,7 +283,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				StringArgs: map[model.StringSignalArgs]struct{}{
 					{
 						Name: vss.FieldPowertrainType,
@@ -308,7 +308,7 @@ func (c *CHServiceTestSuite) TestGetAggSignal() {
 				},
 				FromTS:   c.dataStartTime,
 				ToTS:     endTs,
-				Interval: day.Milliseconds(),
+				Interval: day.Microseconds(),
 				StringArgs: map[model.StringSignalArgs]struct{}{
 					{
 						Name: vss.FieldPowertrainType,
@@ -512,7 +512,7 @@ func (c *CHServiceTestSuite) TestOrginGrouping() {
 		},
 		FromTS:   startTime,
 		ToTS:     endTime,
-		Interval: 28 * day.Milliseconds(),
+		Interval: 28 * day.Microseconds(),
 		FloatArgs: map[model.FloatSignalArgs]struct{}{
 			{
 				Name: vss.FieldSpeed,

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -105,11 +105,14 @@ func withSource(source string) qm.QueryMod {
 }
 
 // selectInterval adds a SELECT clause to the query to select the interval group based on the given milliSeconds.
-func selectInterval(milliSeconds int64, origin time.Time) qm.QueryMod {
+func selectInterval(microSeconds int64, origin time.Time) qm.QueryMod {
 	// Newer version of toStartOfInterval with "origin".
 	// Requires ClickHouse Cloud 24.10.
-	return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMillisecond(%d), fromUnixTimestamp64Micro(%d)) as %s",
-		vss.TimestampCol, milliSeconds, origin.UnixMicro(), IntervalGroup))
+	//
+	// Note that this new overload seems to have a bug when the interval
+	// is an IntervalMilliseconds.
+	return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMicrosecond(%d), fromUnixTimestamp64Micro(%d)) as %s",
+		vss.TimestampCol, microSeconds, origin.UnixMicro(), IntervalGroup))
 }
 
 func selectNumberAggs(numberAggs []model.FloatSignalArgs) qm.QueryMod {

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -109,19 +109,10 @@ func withSource(source string) qm.QueryMod {
 // Round to interval boundaries using toStartOfInterval
 // Restore the original time reference (by adding the origin back).
 func selectInterval(milliSeconds int64, origin time.Time) qm.QueryMod {
-	// TODO (Kevin): Replace this function with simpler toStartOfInterval once ClickHouse prod server is >= v24.9
-	// return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMillisecond(%d), fromUnixTimestamp64Micro(%d)) as %s", vss.TimestampCol, milliSeconds, origin.UnixMicro(), intervalGroup))
-	// https://github.com/ClickHouse/ClickHouse/commit/2c35d53bf67cd80edb4389feac11bcff67233eeb
-	return qm.Select(fmt.Sprintf(`
-	fromUnixTimestamp64Micro(
-		toUnixTimestamp64Micro(
-			toStartOfInterval(
-				fromUnixTimestamp64Micro(toUnixTimestamp64Micro(%s) - %d),
-				toIntervalMillisecond(%d)
-			)
-		) + %d
-	) as %s`,
-		vss.TimestampCol, origin.UnixMicro(), milliSeconds, origin.UnixMicro(), IntervalGroup))
+	// Newer version of toStartOfInterval with "origin".
+	// Requires ClickHouse Cloud 24.10.
+	return qm.Select(fmt.Sprintf("toStartOfInterval(%s, toIntervalMillisecond(%d), fromUnixTimestamp64Micro(%d)) as %s",
+		vss.TimestampCol, milliSeconds, origin.UnixMicro(), IntervalGroup))
 }
 
 func selectNumberAggs(numberAggs []model.FloatSignalArgs) qm.QueryMod {

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -105,9 +105,6 @@ func withSource(source string) qm.QueryMod {
 }
 
 // selectInterval adds a SELECT clause to the query to select the interval group based on the given milliSeconds.
-// Normalize timestamps relative to a specific origin point (by subtracting it)
-// Round to interval boundaries using toStartOfInterval
-// Restore the original time reference (by adding the origin back).
 func selectInterval(milliSeconds int64, origin time.Time) qm.QueryMod {
 	// Newer version of toStartOfInterval with "origin".
 	// Requires ClickHouse Cloud 24.10.


### PR DESCRIPTION
ClickHouse added an overload of [`toStartOfInterval`](https://clickhouse.com/docs/sql-reference/functions/date-time-functions#tostartofinterval) (Cloud in [24.10](https://clickhouse.com/docs/changelogs/24.10#new-feature), OSS in [24.9.1](https://github.com/ClickHouse/ClickHouse/commit/2c35d53bf67cd80edb4389feac11bcff67233eeb)) that accepts an "origin" time. Previously, we were shifting the interval and then shifting the results back.

This PR also tries to use microseconds for intervals, for two reasons:

1. This new overload bugs out when the interval is specified in milliseconds. We filed a bug: https://github.com/ClickHouse/ClickHouse/issues/82453. I would understand if that gave reviewers pause about using this overload at all.
2. The timestamp column is `DateTime64(6)`, so we have the precision lying around.