### PR TITLE
Switch approximate location order internally

### DIFF
--- a/internal/repositories/repositories.go
+++ b/internal/repositories/repositories.go
@@ -126,7 +126,7 @@ func (r *Repository) GetSignal(ctx context.Context, aggArgs *model.AggregatedSig
 	return allAggs, nil
 }
 
-var parityToLocationSignalName = [2]string{vss.FieldCurrentLocationLongitude, vss.FieldCurrentLocationLatitude}
+var parityToLocationSignalName = [2]string{vss.FieldCurrentLocationLatitude, vss.FieldCurrentLocationLongitude}
 
 // GetSignalLatest returns the latest signals for the given tokenID and filter.
 func (r *Repository) GetSignalLatest(ctx context.Context, latestArgs *model.LatestSignalsArgs) (*model.SignalCollection, error) {

--- a/internal/service/ch/ch.go
+++ b/internal/service/ch/ch.go
@@ -165,11 +165,12 @@ type AggSignal struct {
 	// For float and string aggregations this is simply an index
 	// into the corresponding argument array.
 	//
-	// For approximate location, we imagine expanding each element of
-	// the slice model.AllFloatAggregation into two: first the
-	// longitude and then the latitude. So, for example, SignalType = 3
-	// and SignalIndex = 3 means latitude for the 1-th float
-	// aggregation.
+	// For approximate location (SignalType = AppLocType = 3), we
+	// imagine expanding each element of the slice
+	// model.AllFloatAggregation into two: first the latitude and then
+	// the longitude. So, for example, SignalType = 3 and
+	// SignalIndex = 4 means we want approximate latitude (4 % 2 = 0)
+	// for the index 2 (4 / 2 = 2) float aggregation.
 	//
 	// We could get away with a single number, since we know how many
 	// arguments of each type there are, but it appears to us that this

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -369,8 +369,8 @@ func getAggQuery(aggArgs *model.AggregatedSignalArgs) (string, []any, error) {
 	for i, agg := range model.AllFloatAggregation {
 		if _, ok := aggArgs.ApproxLocArgs[agg]; ok {
 			valuesArgs = append(valuesArgs,
-				aggTableEntry(AppLocType, 2*i, vss.FieldCurrentLocationLongitude),
-				aggTableEntry(AppLocType, 2*i+1, vss.FieldCurrentLocationLatitude))
+				aggTableEntry(AppLocType, 2*i, vss.FieldCurrentLocationLatitude),
+				aggTableEntry(AppLocType, 2*i+1, vss.FieldCurrentLocationLongitude))
 		}
 	}
 	valueTable := fmt.Sprintf("VALUES('%s', %s) as %s ON %s.%s = %s.%s", valueTableDef, strings.Join(valuesArgs, ", "), aggTableName, vss.TableName, vss.NameCol, aggTableName, vss.NameCol)


### PR DESCRIPTION
We settled on ordering the tuple in the `value_location` column as lat, lon, hdop. I wanted to align the ordering in our internal treatment (which maybe we should redo) of approximate location with this. Previously, we had lon and then lat, in the GIS tradition.