### PR TITLE
perf(ch): serve latest-state and summary queries from precomputed tables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DIMO-Network/cloudevent v0.2.7
 	github.com/DIMO-Network/credit-tracker v0.0.6
 	github.com/DIMO-Network/fetch-api v0.0.16
-	github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16
+	github.com/DIMO-Network/model-garage v1.0.13
 	github.com/DIMO-Network/server-garage v0.1.1
 	github.com/DIMO-Network/shared v1.1.5
 	github.com/DIMO-Network/token-exchange-api v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DIMO-Network/cloudevent v0.2.7
 	github.com/DIMO-Network/credit-tracker v0.0.6
 	github.com/DIMO-Network/fetch-api v0.0.16
-	github.com/DIMO-Network/model-garage v1.0.11
+	github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16
 	github.com/DIMO-Network/server-garage v0.1.1
 	github.com/DIMO-Network/shared v1.1.5
 	github.com/DIMO-Network/token-exchange-api v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/DIMO-Network/credit-tracker v0.0.6 h1:9C9AXah2uCQKCr7Kqzu2H9aXWj7wEOj
 github.com/DIMO-Network/credit-tracker v0.0.6/go.mod h1:k037ZQMuBcyNj0Czg/jd6GCBC/HihkSsA7c1FRrF2yI=
 github.com/DIMO-Network/fetch-api v0.0.16 h1:jOIM9AHOCTN9Omh5QoRrdVsy0UCPHwB+08/DEI0qnqs=
 github.com/DIMO-Network/fetch-api v0.0.16/go.mod h1:pD9+5wPYjz3ORH9FBsXLlomsZJRPTyOzKy19urT6xew=
-github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16 h1:Tc2RWzUlesuRudzCM3O2gplXb0Gc5nEJFI/TjjcdSAs=
-github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
+github.com/DIMO-Network/model-garage v1.0.13 h1:KwFJ/v6XETGNtiqmP7/FbW9eQTZFVbIpZ6gdHzGL+Rc=
+github.com/DIMO-Network/model-garage v1.0.13/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/server-garage v0.1.1 h1:EYmyy+Fgi2BNW0Bufn04BViDtb8BCWaN7C7BbEuoI5s=
 github.com/DIMO-Network/server-garage v0.1.1/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
 github.com/DIMO-Network/shared v1.1.5 h1:cRI3BbeYOgolMkeBOSqbDVGxymnDfeP/q7xgIXJ5MkY=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/DIMO-Network/credit-tracker v0.0.6 h1:9C9AXah2uCQKCr7Kqzu2H9aXWj7wEOj
 github.com/DIMO-Network/credit-tracker v0.0.6/go.mod h1:k037ZQMuBcyNj0Czg/jd6GCBC/HihkSsA7c1FRrF2yI=
 github.com/DIMO-Network/fetch-api v0.0.16 h1:jOIM9AHOCTN9Omh5QoRrdVsy0UCPHwB+08/DEI0qnqs=
 github.com/DIMO-Network/fetch-api v0.0.16/go.mod h1:pD9+5wPYjz3ORH9FBsXLlomsZJRPTyOzKy19urT6xew=
-github.com/DIMO-Network/model-garage v1.0.11 h1:aLvIyeo58p9pVgz+d3DnU5k5Fxvxh6mq/jE2s3LxXoc=
-github.com/DIMO-Network/model-garage v1.0.11/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
+github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16 h1:Tc2RWzUlesuRudzCM3O2gplXb0Gc5nEJFI/TjjcdSAs=
+github.com/DIMO-Network/model-garage v1.0.13-0.20260611185235-0c372dda2b16/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
 github.com/DIMO-Network/server-garage v0.1.1 h1:EYmyy+Fgi2BNW0Bufn04BViDtb8BCWaN7C7BbEuoI5s=
 github.com/DIMO-Network/server-garage v0.1.1/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
 github.com/DIMO-Network/shared v1.1.5 h1:cRI3BbeYOgolMkeBOSqbDVGxymnDfeP/q7xgIXJ5MkY=

--- a/internal/service/ch/ch.go
+++ b/internal/service/ch/ch.go
@@ -74,9 +74,9 @@ func getMaxExecutionTime(maxRequestDuration string) (int, error) {
 }
 
 // GetLatestSignals returns the latest signals based on the provided arguments
-// from the ClickHouse database. The queries are answered by the
-// signal_latest_by_subject_source_name projection, so no time bound is
-// applied; results reflect the full history of the subject.
+// from the ClickHouse database. The queries are answered by the precomputed
+// signal_latest table, so no time bound is applied; results reflect the full
+// history of the subject.
 func (s *Service) GetLatestSignals(ctx context.Context, subject string, latestArgs *model.LatestSignalsArgs) ([]*vss.Signal, error) {
 	stmt, args := getLatestQuery(subject, latestArgs)
 	if latestArgs.IncludeLastSeen {
@@ -314,8 +314,8 @@ type EventSummary struct {
 }
 
 // GetEventSummaries returns per-event summaries (name, count, first/last seen)
-// for a subject (vehicle), over all time. Relies on the (subject, source, name)
-// projection on the event table for acceptable performance.
+// for a subject (vehicle), over all time, read from the precomputed
+// event_summary table.
 func (s *Service) GetEventSummaries(ctx context.Context, subject string) ([]*EventSummary, error) {
 	stmt, args := getEventSummariesQuery(subject)
 	rows, err := s.conn.Query(ctx, stmt, args...)

--- a/internal/service/ch/ch_test.go
+++ b/internal/service/ch/ch_test.go
@@ -938,36 +938,6 @@ func (c *CHServiceTestSuite) TestGetLatestSignal() {
 	}
 }
 
-// TestLatestQueriesUseProjection asserts that every branch of the latest-signals
-// query family can be served by the signal_latest_by_subject_source_name
-// projection. A branch that falls back to the base table scans the subject's
-// entire signal history, so its cost grows with history depth instead of with
-// the request. force_optimize_projection makes ClickHouse reject any query the
-// projection matcher cannot serve.
-func (c *CHServiceTestSuite) TestLatestQueriesUseProjection() {
-	lastSeenStmt, lastSeenArgs := getLastSeenQuery(testSubject1, &model.SignalArgs{})
-	nonLocStmt, nonLocArgs := getLatestNonLocationQuery(testSubject1, []string{vss.FieldSpeed}, nil)
-	locStmt, locArgs := getLatestLocationQuery(testSubject1, []string{vss.FieldCurrentLocationCoordinates}, nil)
-
-	testCases := []struct {
-		name string
-		stmt string
-		args []any
-	}{
-		{name: "lastSeen", stmt: lastSeenStmt, args: lastSeenArgs},
-		{name: "nonLocation", stmt: nonLocStmt, args: nonLocArgs},
-		{name: "location", stmt: locStmt, args: locArgs},
-	}
-	for _, tc := range testCases {
-		c.Run(tc.name, func() {
-			stmt := strings.TrimSuffix(tc.stmt, ";") + " SETTINGS force_optimize_projection = 1"
-			rows, err := c.chService.conn.Query(context.Background(), stmt, tc.args...)
-			c.Require().NoError(err, "query is not served by a projection:\n%s", tc.stmt)
-			c.Require().NoError(rows.Close())
-		})
-	}
-}
-
 func (c *CHServiceTestSuite) TestGetAvailableSignals() {
 	ctx := context.Background()
 	c.Run("has signals", func() {

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -33,6 +33,24 @@ const (
 	valueTableDef = signalTypeCol + " UInt8, " + signalIndexCol + " UInt16, " + vss.NameCol + " String"
 )
 
+const (
+	// latestTableName is the precomputed latest-state table (model-garage
+	// migration 00010). One row per (subject, kind, name, source).
+	latestTableName = "signal_latest"
+	latestKindCol   = "kind"
+	// kindRaw rows hold the latest raw value per signal.
+	kindRaw = 0
+	// kindNonZeroLoc rows hold the latest non-(0,0) location per signal.
+	kindNonZeroLoc = 1
+
+	// Summary tables (model-garage migration 00011).
+	signalSummaryTableName = "signal_summary"
+	eventSummaryTableName  = "event_summary"
+	summaryCountCol        = "count"
+	summaryFirstSeenCol    = "first_seen"
+	summaryLastSeenCol     = "last_seen"
+)
+
 // variables for the last seen signal query.
 const (
 	lastSeenName = "'" + model.LastSeenField + "' AS name"
@@ -43,20 +61,16 @@ const (
 	lastSeenTS = "max(" + vss.TimestampCol + ") AS ts"
 )
 
-// Aggregation functions for latest signals. Shapes must stay byte-identical
-// to the aggregates in the signal_latest_by_subject_source_name projection;
-// ClickHouse matches projections by exact aggregate-expression text.
+// Aggregation functions for latest signals, read from the signal_latest
+// table. The table holds a handful of rows per (subject, kind, name, source);
+// argMax/max collapse any rows ReplacingMergeTree has not merged yet, so
+// results are exact regardless of merge state. kind=1 rows are pre-filtered
+// to non-(0,0) locations, so plain argMax replaces the old argMaxIf shapes.
 const (
 	latestString    = "argMax(" + vss.ValueStringCol + ", " + vss.TimestampCol + ") as " + vss.ValueStringCol
 	latestNumber    = "argMax(" + vss.ValueNumberCol + ", " + vss.TimestampCol + ") as " + vss.ValueNumberCol
 	latestTimestamp = "max(" + vss.TimestampCol + ") as ts"
-
-	// latestLocationCond excludes (0, 0) points from the latest-location
-	// computation. Kept in sync with the projection's argMaxIf/maxIf
-	// conditions.
-	latestLocationCond = "(tupleElement(" + vss.ValueLocationCol + ", 'latitude') != 0) OR (tupleElement(" + vss.ValueLocationCol + ", 'longitude') != 0)"
-	latestLocation     = "argMaxIf(" + vss.ValueLocationCol + ", " + vss.TimestampCol + ", " + latestLocationCond + ") as " + AggLocationCol
-	latestLocationTS   = "maxIf(" + vss.TimestampCol + ", " + latestLocationCond + ") as ts"
+	latestLocation  = "argMax(" + vss.ValueLocationCol + ", " + vss.TimestampCol + ") as " + AggLocationCol
 )
 
 // Aggregation functions for string signals.
@@ -310,17 +324,13 @@ func batchLocationCaseExprWithAlias(alias string, locationArgs []model.LocationS
 }
 
 // getLatestQuery builds the query (or UNION ALL of queries) that returns the
-// latest value per signal name for a subject.
+// latest value per signal name for a subject, read from the signal_latest
+// table (model-garage migration 00010).
 //
-// Non-location and location signals use different aggregate shapes so both
-// match the signal_latest_by_subject_source_name projection:
-//
-//   - non-location: argMax(value_*, timestamp), max(timestamp)
-//   - location:     argMaxIf/maxIf filtered by "location is not (0, 0)"
-//
-// Each branch is a separate SELECT so the projection matcher (which is
-// byte-sensitive to aggregate expressions) matches each cleanly. The queries
-// are combined with UNION ALL.
+// Non-location signals read kind=0 rows (latest raw value); location signals
+// read kind=1 rows, which only ever contain non-(0,0) fixes, preserving the
+// old argMaxIf-over-history semantics. The branches are combined with
+// UNION ALL.
 func getLatestQuery(subject string, latestArgs *model.LatestSignalsArgs) (string, []any) {
 	signalNames := make([]string, 0, len(latestArgs.SignalNames))
 	for name := range latestArgs.SignalNames {
@@ -353,8 +363,10 @@ func getLatestQuery(subject string, latestArgs *model.LatestSignalsArgs) (string
 	return unionAll(stmts, args)
 }
 
-// getLatestNonLocationQuery selects max(ts), argMax(value_number), argMax(value_string)
-// for the given signal names. Shape is aligned with the projection aggregates.
+// getLatestNonLocationQuery returns the latest value per requested non-location
+// signal from signal_latest. argMax over the (subject, kind, name, source) rows
+// makes the result exact even before ReplacingMergeTree merges collapse
+// superseded rows.
 func getLatestNonLocationQuery(subject string, signalNames []string, filter *model.SignalFilter) (string, []any) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.NameCol),
@@ -363,8 +375,9 @@ func getLatestNonLocationQuery(subject string, signalNames []string, filter *mod
 		qm.Select(latestString),
 		// keep the same output column set as the location branch so UNION ALL stays well-typed
 		qm.Select(locValAsZero),
-		qm.From(vss.TableName),
+		qm.From(latestTableName),
 		qm.Where(subjectWhere, subject),
+		qmhelper.Where(latestKindCol, qmhelper.EQ, uint8(kindRaw)),
 		qm.WhereIn(nameIn, signalNames),
 		qm.GroupBy(vss.NameCol),
 	}
@@ -372,18 +385,19 @@ func getLatestNonLocationQuery(subject string, signalNames []string, filter *mod
 	return newQuery(mods...)
 }
 
-// getLatestLocationQuery selects maxIf(ts)/argMaxIf(value_location) filtered
-// to rows where the location is not (0, 0). Matches the projection's
-// argMaxIf/maxIf aggregates exactly.
+// getLatestLocationQuery returns the latest valid (non-(0,0)) location per
+// requested location signal. kind=1 rows only ever contain non-(0,0) fixes,
+// so a plain argMax replicates the previous argMaxIf-over-history semantics.
 func getLatestLocationQuery(subject string, locationSignalNames []string, filter *model.SignalFilter) (string, []any) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.NameCol),
-		qm.Select(latestLocationTS),
+		qm.Select(latestTimestamp),
 		qm.Select(numValAsNull),
 		qm.Select(strValAsNull),
 		qm.Select(latestLocation),
-		qm.From(vss.TableName),
+		qm.From(latestTableName),
 		qm.Where(subjectWhere, subject),
+		qmhelper.Where(latestKindCol, qmhelper.EQ, uint8(kindNonZeroLoc)),
 		qm.WhereIn(nameIn, locationSignalNames),
 		qm.GroupBy(vss.NameCol),
 	}
@@ -391,22 +405,8 @@ func getLatestLocationQuery(subject string, locationSignalNames []string, filter
 	return newQuery(mods...)
 }
 
-// getAllLatestQuery creates a query to get the latest signal value for ALL signal names.
-// Unlike getLatestQuery, this does not filter by signal name.
-/*
-SELECT
-  name,
-  max(timestamp),
-  argMax(value_string, timestamp) as value_string,
-  argMax(value_number, timestamp) as value_number,
-  argMax(value_location, timestamp) as value_location
-FROM
-  signal
-WHERE
-  subject = '...'
-GROUP BY
-  name
-*/
+// getAllLatestQuery returns the latest raw value for every signal name of the
+// subject from signal_latest.
 func getAllLatestQuery(subject string, filter *model.SignalFilter) (string, []any) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.NameCol),
@@ -414,47 +414,34 @@ func getAllLatestQuery(subject string, filter *model.SignalFilter) (string, []an
 		qm.Select(latestNumber),
 		qm.Select(latestString),
 		qm.Select(latestLocation),
-		qm.From(vss.TableName),
+		qm.From(latestTableName),
 		qm.Where(subjectWhere, subject),
+		qmhelper.Where(latestKindCol, qmhelper.EQ, uint8(kindRaw)),
 		qm.GroupBy(vss.NameCol),
 	}
 	mods = append(mods, getFilterMods(filter)...)
 	return newQuery(mods...)
 }
 
-// getLastSeenQuery creates a query to get the last seen timestamp of any signal.
-// returns the query statement and the arguments list,
-//
-// The inner query aggregates at the same grain as the
-// signal_latest_by_subject_source_name projection (GROUP BY name with subject
-// pinned) so the projection matcher serves it from pre-aggregated rows. A flat
-// max(timestamp) with no GROUP BY is not reliably matched and falls back to
-// scanning the subject's full history.
-/*
-SELECT
-	'lastSeen' AS name,
-	max(ts) AS ts,
-	NULL AS value_number,
-	NULL AS value_string,
-	CAST(tuple(0, 0, 0, 0), 'Tuple(latitude Float64, longitude Float64, hdop Float64, heading Float64)') AS value_location
-FROM
-	(SELECT max(timestamp) AS ts FROM signal WHERE subject = '...' GROUP BY name)
-*/
+// getLastSeenQuery returns the most recent timestamp across all of the
+// subject's signals. signal_latest holds at most a few hundred rows per
+// subject, so the flat aggregate is a point lookup.
 func getLastSeenQuery(subject string, sigArgs *model.SignalArgs) (string, []any) {
 	if sigArgs == nil {
 		return "", nil
 	}
-	innerMods := []qm.QueryMod{
+	mods := []qm.QueryMod{
+		qm.Select(lastSeenName),
 		qm.Select(lastSeenTS),
-		qm.From(vss.TableName),
+		qm.Select(numValAsNull),
+		qm.Select(strValAsNull),
+		qm.Select(locValAsZero),
+		qm.From(latestTableName),
 		qm.Where(subjectWhere, subject),
-		qm.GroupBy(vss.NameCol),
+		qmhelper.Where(latestKindCol, qmhelper.EQ, uint8(kindRaw)),
 	}
-	innerMods = append(innerMods, getFilterMods(sigArgs.Filter)...)
-	innerStmt, args := newQuery(innerMods...)
-	stmt := "SELECT " + lastSeenName + ", max(ts) AS ts, " + numValAsNull + ", " + strValAsNull + ", " + locValAsZero +
-		" FROM (" + strings.TrimSuffix(innerStmt, ";") + ");"
-	return stmt, args
+	mods = append(mods, getFilterMods(sigArgs.Filter)...)
+	return newQuery(mods...)
 }
 
 // unionAll creates a UNION ALL statement from the given statements and arguments.
@@ -780,32 +767,31 @@ func buildSegmentIndexMultiIf(timestampCol string, ranges []TimeRange) string {
 	return "multiIf(" + strings.Join(parts, ", ") + ", -1) AS seg_idx"
 }
 
-// getDistinctQuery returns distinct signal names seen for a subject. Uses
-// GROUP BY (not DISTINCT) so the ClickHouse planner can match the
-// (subject, source, name) aggregating projection on the signal table; without
-// that projection this is a full-history scan per subject.
+// getDistinctQuery returns distinct signal names seen for a subject, read
+// from the signal_latest table, which holds one row per
+// (subject, kind, name, source) plus any not-yet-merged duplicates.
 func getDistinctQuery(subject string, filter *model.SignalFilter) (string, []any) {
 	mods := []qm.QueryMod{
-		qm.Select(vss.NameCol),
-		qm.From(vss.TableName),
+		qm.Distinct(vss.NameCol),
+		qm.From(latestTableName),
 		qm.Where(subjectWhere, subject),
-		qm.GroupBy(vss.NameCol),
+		qmhelper.Where(latestKindCol, qmhelper.EQ, uint8(kindRaw)),
 		qm.OrderBy(vss.NameCol),
 	}
 	mods = append(mods, getFilterMods(filter)...)
 	return newQuery(mods...)
 }
 
-// getSignalSummariesQuery summarizes signals by name for a subject. Relies on
-// the (subject, source, name) projection on the signal table to keep this
-// cheap; without that projection this is a full-history scan per subject.
+// getSignalSummariesQuery returns per-name count and first/last seen from the
+// signal_summary table. sum/min/max re-aggregate the partial rows the MV and
+// merges produce, so results are exact regardless of merge state.
 func getSignalSummariesQuery(subject string, filter *model.SignalFilter) (string, []any) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.NameCol),
-		qm.Select("COUNT(*)"),
-		qm.Select("MIN(" + vss.TimestampCol + ")"),
-		qm.Select("MAX(" + vss.TimestampCol + ")"),
-		qm.From(vss.TableName),
+		qm.Select("sum(" + summaryCountCol + ")"),
+		qm.Select("min(" + summaryFirstSeenCol + ")"),
+		qm.Select("max(" + summaryLastSeenCol + ")"),
+		qm.From(signalSummaryTableName),
 		qm.Where(subjectWhere, subject),
 		qm.GroupBy(vss.NameCol),
 		qm.OrderBy(vss.NameCol),
@@ -842,16 +828,15 @@ func appendEventFilterMods(mods []qm.QueryMod, filter *model.EventFilter) []qm.Q
 	return mods
 }
 
-// getEventSummariesQuery summarizes events by name for a subject. Relies on
-// the (subject, source, name) projection on the event table to keep this
-// cheap; without that projection this is a full-history scan per subject.
+// getEventSummariesQuery returns per-name event count and first/last seen from
+// the event_summary table.
 func getEventSummariesQuery(subject string) (string, []any) {
 	mods := []qm.QueryMod{
 		qm.Select(vss.EventNameCol + " AS name"),
-		qm.Select("count(*) AS count"),
-		qm.Select("MIN(" + vss.EventTimestampCol + ") AS first_seen"),
-		qm.Select("MAX(" + vss.EventTimestampCol + ") AS last_seen"),
-		qm.From(vss.EventTableName),
+		qm.Select("sum(" + summaryCountCol + ") AS count"),
+		qm.Select("min(" + summaryFirstSeenCol + ") AS first_seen"),
+		qm.Select("max(" + summaryLastSeenCol + ") AS last_seen"),
+		qm.From(eventSummaryTableName),
 		qm.Where(eventSubjectWhere, subject),
 		qm.GroupBy(vss.EventNameCol),
 		qm.OrderBy(vss.EventNameCol),

--- a/internal/service/ch/queries.go
+++ b/internal/service/ch/queries.go
@@ -70,7 +70,7 @@ const (
 	latestString    = "argMax(" + vss.ValueStringCol + ", " + vss.TimestampCol + ") as " + vss.ValueStringCol
 	latestNumber    = "argMax(" + vss.ValueNumberCol + ", " + vss.TimestampCol + ") as " + vss.ValueNumberCol
 	latestTimestamp = "max(" + vss.TimestampCol + ") as ts"
-	latestLocation  = "argMax(" + vss.ValueLocationCol + ", " + vss.TimestampCol + ") as " + AggLocationCol
+	latestLocation  = "argMax(" + vss.ValueLocationCol + ", " + vss.TimestampCol + ") as " + vss.ValueLocationCol
 )
 
 // Aggregation functions for string signals.

--- a/internal/service/ch/queries_test.go
+++ b/internal/service/ch/queries_test.go
@@ -41,23 +41,52 @@ func TestGetLastSeenQuery(t *testing.T) {
 		assert.Nil(t, args)
 	})
 
-	t.Run("aggregates at projection grain", func(t *testing.T) {
+	t.Run("reads signal_latest", func(t *testing.T) {
 		stmt, args := getLastSeenQuery("subj", &model.SignalArgs{})
-		want := "SELECT 'lastSeen' AS name, max(ts) AS ts, NULL AS value_number, NULL AS value_string, " +
+		want := "SELECT 'lastSeen' AS name, max(timestamp) AS ts, NULL AS value_number, NULL AS value_string, " +
 			"CAST(tuple(0, 0, 0, 0), 'Tuple(latitude Float64, longitude Float64, hdop Float64, heading Float64)') AS value_location " +
-			"FROM (SELECT max(timestamp) AS ts FROM `signal` WHERE (subject = ?) GROUP BY name);"
+			"FROM `signal_latest` WHERE (subject = ?) AND (kind = ?);"
 		assert.Equal(t, want, stmt)
-		assert.Equal(t, []any{"subj"}, args)
+		assert.Equal(t, []any{"subj", uint8(0)}, args)
 	})
 
-	t.Run("source filter stays in inner query", func(t *testing.T) {
+	t.Run("source filter applies", func(t *testing.T) {
 		stmt, args := getLastSeenQuery("subj", &model.SignalArgs{
 			Filter: &model.SignalFilter{Source: ref("0xcd445F4c6bDAD32b68a2939b912150Fe3C88803E")},
 		})
-		want := "SELECT 'lastSeen' AS name, max(ts) AS ts, NULL AS value_number, NULL AS value_string, " +
+		want := "SELECT 'lastSeen' AS name, max(timestamp) AS ts, NULL AS value_number, NULL AS value_string, " +
 			"CAST(tuple(0, 0, 0, 0), 'Tuple(latitude Float64, longitude Float64, hdop Float64, heading Float64)') AS value_location " +
-			"FROM (SELECT max(timestamp) AS ts FROM `signal` WHERE (subject = ?) AND (source = ?) GROUP BY name);"
+			"FROM `signal_latest` WHERE (subject = ?) AND (kind = ?) AND (source = ?);"
 		assert.Equal(t, want, stmt)
-		assert.Equal(t, []any{"subj", "0xcd445F4c6bDAD32b68a2939b912150Fe3C88803E"}, args)
+		assert.Equal(t, []any{"subj", uint8(0), "0xcd445F4c6bDAD32b68a2939b912150Fe3C88803E"}, args)
 	})
+}
+
+func TestGetLatestQueriesReadLatestTable(t *testing.T) {
+	nonLoc, _ := getLatestNonLocationQuery("subj", []string{"speed"}, nil)
+	assert.Contains(t, nonLoc, "FROM `signal_latest`")
+	assert.Contains(t, nonLoc, "(kind = ?)")
+
+	loc, _ := getLatestLocationQuery("subj", []string{"currentLocationCoordinates"}, nil)
+	assert.Contains(t, loc, "FROM `signal_latest`")
+	assert.Contains(t, loc, "(kind = ?)")
+	assert.NotContains(t, loc, "argMaxIf") // kind=1 rows are pre-filtered; plain argMax suffices
+
+	all, _ := getAllLatestQuery("subj", nil)
+	assert.Contains(t, all, "FROM `signal_latest`")
+	assert.Contains(t, all, "(kind = ?)")
+
+	distinct, _ := getDistinctQuery("subj", nil)
+	assert.Contains(t, distinct, "FROM `signal_latest`")
+	assert.Contains(t, distinct, "(kind = ?)")
+}
+
+func TestSummaryQueriesReadSummaryTables(t *testing.T) {
+	sig, _ := getSignalSummariesQuery("subj", nil)
+	assert.Contains(t, sig, "FROM `signal_summary`")
+	assert.Contains(t, sig, "sum(count)")
+
+	ev, _ := getEventSummariesQuery("subj")
+	assert.Contains(t, ev, "FROM `event_summary`")
+	assert.Contains(t, ev, "sum(count)")
 }


### PR DESCRIPTION
## Summary
- signalsLatest / signalsSnapshot / lastSeen / availableSignals now read the precomputed `signal_latest` table (ReplacingMergeTree, model-garage 00010) instead of fanning out across every part of the ~97B-row `signal` table.
- dataSummary per-name count/first-seen/last-seen now read `signal_summary`/`event_summary` (AggregatingMergeTree, model-garage 00011).
- Location fields read kind=1 rows (pre-filtered non-(0,0) fixes) — plain argMax replaces argMaxIf, same semantics.
- Readers aggregate at query time (argMax/max/sum/min); never FINAL — exact regardless of merge state.
- Removes `TestLatestQueriesUseProjection` (asserted the projections being dropped in model-garage 00012).

## Evidence (prod, 2026-06-11)
Projections are stored per part, so latest-state reads inherit the ~140-part fan-out: signalsLatest via projection p50 = 2995ms (31,467 queries/day) vs raw primary-key reads p50 = 110ms. Point lookups on signal_latest target single-digit ms.

## Rollout (order matters)
1. model-garage DIMO-Network/model-garage#263 merged + tagged v1.0.13 (00010+00011).
2. Prod migration job runs @v1.0.13; operator runs the 4 backfill INSERTs (SQL in migration comments).
3. **Then** this PR deploys (re-pin go.mod to v1.0.13 tag before merge).
4. After 24h soak + query_log gate: model-garage DIMO-Network/model-garage#264 (00012 drop projections) = v1.0.14.

## Test plan
- Shape unit tests for all rewritten builders (signal_latest / kind filters / summary tables).
- Full ch container suite + e2e pass (migrations 00010/00011 applied in testcontainer; inserts flow through the new MVs, so behavior tests exercise the new read paths).
- make lint: 0 issues.