### PR TITLE
chore: bump server-garage to v0.4.1

### DIFF
--- a/e2e/mcp_test.go
+++ b/e2e/mcp_test.go
@@ -360,3 +360,43 @@ func TestMCPSignalTools(t *testing.T) {
 		assert.Contains(t, text, "unauthorized")
 	})
 }
+
+// TestMCPNumericArgs covers the two argument shapes that historically broke on
+// gqlgen's Int coercion: raw telemetry_query variables, and Ints nested inside
+// object-typed shortcut args (server-garage #40).
+func TestMCPNumericArgs(t *testing.T) {
+	services := GetTestServices(t)
+	server := newMCPServer(t, services.Settings)
+	token := services.Auth.CreateVehicleToken(t, mcpTestTokenID, []string{tokenclaims.PermissionGetNonLocationHistory, tokenclaims.PermissionGetLocationHistory})
+
+	assertNoGraphQLErrors := func(t *testing.T, text string, isError bool) {
+		t.Helper()
+		require.False(t, isError, "tool error: %s", text)
+		var resp struct {
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &resp))
+		require.Empty(t, resp.Errors, "GraphQL errors: %s", text)
+	}
+
+	t.Run("query tool accepts Int variables", func(t *testing.T) {
+		text, isError := callTool(t, server.URL, token, "telemetry_query", map[string]any{
+			"query":     `query($tokenId: Int!) { signalsLatest(tokenId: $tokenId) { lastSeen } }`,
+			"variables": map[string]any{"tokenId": mcpTestTokenID},
+		})
+		assertNoGraphQLErrors(t, text, isError)
+	})
+
+	t.Run("shortcut tool accepts Int nested in object arg", func(t *testing.T) {
+		text, isError := callTool(t, server.URL, token, "telemetry_get_trip_segments", map[string]any{
+			"tokenId":   mcpTestTokenID,
+			"from":      "2024-11-20T00:00:00Z",
+			"to":        "2024-11-21T00:00:00Z",
+			"mechanism": "ignitionDetection",
+			"config":    map[string]any{"maxGapSeconds": 300},
+		})
+		assertNoGraphQLErrors(t, text, isError)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DIMO-Network/credit-tracker v0.0.6
 	github.com/DIMO-Network/fetch-api v0.0.16
 	github.com/DIMO-Network/model-garage v1.0.13
-	github.com/DIMO-Network/server-garage v0.4.0
+	github.com/DIMO-Network/server-garage v0.4.1
 	github.com/DIMO-Network/shared v1.1.5
 	github.com/DIMO-Network/token-exchange-api v0.4.0
 	github.com/aarondl/sqlboiler/v4 v4.19.5

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/DIMO-Network/fetch-api v0.0.16 h1:jOIM9AHOCTN9Omh5QoRrdVsy0UCPHwB+08/
 github.com/DIMO-Network/fetch-api v0.0.16/go.mod h1:pD9+5wPYjz3ORH9FBsXLlomsZJRPTyOzKy19urT6xew=
 github.com/DIMO-Network/model-garage v1.0.13 h1:KwFJ/v6XETGNtiqmP7/FbW9eQTZFVbIpZ6gdHzGL+Rc=
 github.com/DIMO-Network/model-garage v1.0.13/go.mod h1:oi7EGKQVxFVpXRsu2H+YbizbKcx06aQg2N1Yu4GqOp8=
-github.com/DIMO-Network/server-garage v0.4.0 h1:3ukXvtldIhLldn9AtbtQBooBjT2gicvB3WphrsjNQho=
-github.com/DIMO-Network/server-garage v0.4.0/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
+github.com/DIMO-Network/server-garage v0.4.1 h1:YJyW74jYQn0yUb+NWjA9FK4olws6VZKOnn3J+ekC3vo=
+github.com/DIMO-Network/server-garage v0.4.1/go.mod h1:Z3A1KDUsXey+XhrPhmw/wyCidfrQvmEdWp7nShno7ZM=
 github.com/DIMO-Network/shared v1.1.5 h1:cRI3BbeYOgolMkeBOSqbDVGxymnDfeP/q7xgIXJ5MkY=
 github.com/DIMO-Network/shared v1.1.5/go.mod h1:lDHUKwwT2LW6Zvd42Nb33dXklRNTmfyOlbUNx2dQfGY=
 github.com/DIMO-Network/token-exchange-api v0.4.0 h1:EayDrw9VdyAfc6rbpdnDxFhlN3lMhbonUJoouKZu35g=


### PR DESCRIPTION
Picks up [server-garage v0.4.1](https://github.com/DIMO-Network/server-garage/releases/tag/v0.4.1) (DIMO-Network/server-garage#40): MCP tool arguments now decode as `json.Number` from raw wire bytes.

Fixes on the `/mcp` endpoint:
- `telemetry_query` with Int GraphQL variables no longer fails with `float64 is not an int` (previously only inlined literals worked)
- Int fields nested inside object args now work, e.g. `telemetry_get_trip_segments` / `telemetry_get_daily_activity` with `config: {maxGapSeconds: ...}`
- Integer values above 2^53 (`Uint64` scalars) no longer silently lose precision

Adds e2e `TestMCPNumericArgs` covering both payload shapes through the real app + ClickHouse; it fails on v0.4.0 and passes on v0.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmwEoviMaEuuhRkfmks8wa