### PR TITLE
fix(repositories): filter unqueryable signals from dataSummary

### DIFF
--- a/internal/repositories/repositories.go
+++ b/internal/repositories/repositories.go
@@ -229,9 +229,19 @@ func (r *Repository) GetSignalSnapshot(ctx context.Context, tokenID uint32, filt
 // GetDataSummary returns the signal and event metadata for the given tokenID and filter.
 func (r *Repository) GetDataSummary(ctx context.Context, tokenID uint32, filter *model.SignalFilter) (*model.DataSummary, error) {
 	subject := r.toSubject(tokenID)
-	signalDataSummary, err := r.chService.GetSignalSummaries(ctx, subject, filter)
+	allSignalSummaries, err := r.chService.GetSignalSummaries(ctx, subject, filter)
 	if err != nil {
 		return nil, handleDBError(ctx, err)
+	}
+	// Same queryable filter as availableSignals / signalsSnapshot: stored
+	// names that left the GraphQL schema (e.g. currentLocationIsRedacted)
+	// must not be advertised — callers feed these names back into signal
+	// queries and get validation errors.
+	signalDataSummary := make([]*model.SignalDataSummary, 0, len(allSignalSummaries))
+	for _, metadata := range allSignalSummaries {
+		if _, ok := r.queryableSignals[metadata.Name]; ok {
+			signalDataSummary = append(signalDataSummary, metadata)
+		}
 	}
 	eventSummaries, err := r.chService.GetEventSummaries(ctx, subject)
 	if err != nil {

--- a/internal/repositories/repositories_test.go
+++ b/internal/repositories/repositories_test.go
@@ -514,3 +514,43 @@ func TestGetEvents(t *testing.T) {
 func ref[T any](t T) *T {
 	return &t
 }
+
+// TestGetDataSummaryFiltersUnqueryableSignals pins dataSummary to the same
+// queryable-signal filter used by availableSignals and signalsSnapshot.
+// Stored names that are no longer in the GraphQL schema (prod example:
+// currentLocationIsRedacted) must not be advertised — agents feed these names
+// back into signal queries and get GRAPHQL_VALIDATION_FAILED.
+func TestGetDataSummaryFiltersUnqueryableSignals(t *testing.T) {
+	testSubject := cloudevent.ERC721DID{
+		ChainID:         baseSettings.ChainID,
+		ContractAddress: baseSettings.VehicleNFTAddress,
+		TokenID:         big.NewInt(1),
+	}.String()
+
+	queryableSeen := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	staleSeen := time.Date(2024, 7, 22, 10, 41, 26, 0, time.UTC)
+
+	mocks := setupMocks(t)
+	mocks.CHService.EXPECT().
+		GetSignalSummaries(gomock.Any(), testSubject, nil).
+		Return([]*model.SignalDataSummary{
+			{Name: "speed", NumberOfSignals: 10, FirstSeen: queryableSeen, LastSeen: queryableSeen},
+			{Name: "currentLocationIsRedacted", NumberOfSignals: 5, FirstSeen: staleSeen, LastSeen: staleSeen},
+		}, nil)
+	mocks.CHService.EXPECT().
+		GetEventSummaries(gomock.Any(), testSubject).
+		Return(nil, nil)
+
+	repo, err := repositories.NewRepository(mocks.CHService, baseSettings)
+	require.NoError(t, err)
+
+	result, err := repo.GetDataSummary(context.Background(), 1, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"speed"}, result.AvailableSignals)
+	require.Len(t, result.SignalDataSummary, 1)
+	require.Equal(t, "speed", result.SignalDataSummary[0].Name)
+	require.Equal(t, uint64(10), result.NumberOfSignals, "counts must exclude unqueryable signals")
+	require.Equal(t, queryableSeen, result.FirstSeen, "first/last seen must exclude unqueryable signals")
+	require.Equal(t, queryableSeen, result.LastSeen)
+}


### PR DESCRIPTION
## Problem

`dataSummary` forwards stored signal names raw from ClickHouse, while `availableSignals` and `signalsSnapshot` filter them against the GraphQL schema's queryable set. Stored-but-removed names leak into `availableSignals` / `signalDataSummary` — prod example: `currentLocationIsRedacted` (last written 2024). Agents and API consumers feed those names back into signal queries and get `GRAPHQL_VALIDATION_FAILED`.

Follow-up to #304 (same 2026-08-03 incident class: API advertising names that fail when queried).

## Fix

`GetDataSummary` applies the same `queryableSignals` filter before building the summary; `numberOfSignals` and `firstSeen`/`lastSeen` aggregate over queryable signals only.

## Tests

`TestGetDataSummaryFiltersUnqueryableSignals` — RED against the old code with the exact prod leak (`currentLocationIsRedacted` in the advertised list), GREEN after. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hwzo7z9hmuqgJ2SHPusac